### PR TITLE
Enable Arm64 optimization on Windows

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -49,6 +49,10 @@
 #   else
 #    error "unsupported ARM architecture"
 #   endif
+#  else
+#   if  defined(__ARM_ARCH)
+#    define __ARM_ARCH__ __ARM_ARCH
+#   endif
 #  endif
 # endif
 

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -369,7 +369,7 @@ void gcm_gmult_4bit_x86(u64 Xi[2], const u128 Htable[16]);
 void gcm_ghash_4bit_x86(u64 Xi[2], const u128 Htable[16], const u8 *inp,
                         size_t len);
 #  endif
-# elif defined(__arm__) || defined(__arm) || defined(__aarch64__)
+# elif defined(__arm__) || defined(__arm) || defined(__aarch64__) || defined(_M_ARM64)
 #  include "arm_arch.h"
 #  if __ARM_MAX_ARCH__>=7
 #   define GHASH_ASM_ARM

--- a/crypto/sm3/sm3_local.h
+++ b/crypto/sm3/sm3_local.h
@@ -34,7 +34,7 @@
       } while (0)
 
 #if defined(OPENSSL_SM3_ASM)
-# if defined(__aarch64__)
+# if defined(__aarch64__) || defined(_M_ARM64)
 #  include "crypto/arm_arch.h"
 #  define HWSM3_CAPABLE (OPENSSL_armcap_P & ARMV8_SM3)
 void ossl_hwsm3_block_data_order(SM3_CTX *c, const void *p, size_t num);

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -90,7 +90,7 @@ void gcm_ghash_p8(u64 Xi[2],const u128 Htable[16],const u8 *inp, size_t len);
 #   endif /* OPENSSL_SYS_AIX || OPENSSL_SYS_MACOSX */
 #  endif /* PPC */
 
-#  if (defined(__arm__) || defined(__arm) || defined(__aarch64__))
+#  if (defined(__arm__) || defined(__arm) || defined(__aarch64__) || defined(_M_ARM64)) 
 #   include "arm_arch.h"
 #   if __ARM_MAX_ARCH__>=7
 #    if defined(BSAES_ASM)
@@ -106,7 +106,7 @@ void gcm_ghash_p8(u64 Xi[2],const u128 Htable[16],const u8 *inp, size_t len);
 #    define HWAES_decrypt aes_v8_decrypt
 #    define HWAES_cbc_encrypt aes_v8_cbc_encrypt
 #    define HWAES_ecb_encrypt aes_v8_ecb_encrypt
-#    if __ARM_MAX_ARCH__>=8 && defined(__aarch64__)
+#    if __ARM_MAX_ARCH__>=8 && (defined(__aarch64__) || defined(_M_ARM64))
 #     define HWAES_xts_encrypt aes_v8_xts_encrypt
 #     define HWAES_xts_decrypt aes_v8_xts_decrypt
 #    endif
@@ -114,7 +114,7 @@ void gcm_ghash_p8(u64 Xi[2],const u128 Htable[16],const u8 *inp, size_t len);
 #    define AES_PMULL_CAPABLE ((OPENSSL_armcap_P & ARMV8_PMULL) && (OPENSSL_armcap_P & ARMV8_AES))
 #    define AES_GCM_ENC_BYTES 512
 #    define AES_GCM_DEC_BYTES 512
-#    if __ARM_MAX_ARCH__>=8 && defined(__aarch64__)
+#    if __ARM_MAX_ARCH__>=8 && (defined(__aarch64__) || defined(_M_ARM64))
 #     define AES_gcm_encrypt armv8_aes_gcm_encrypt
 #     define AES_gcm_decrypt armv8_aes_gcm_decrypt
 #     define AES_GCM_ASM(gctx) ((gctx)->ctr==aes_v8_ctr32_encrypt_blocks && \

--- a/include/crypto/sm4_platform.h
+++ b/include/crypto/sm4_platform.h
@@ -12,7 +12,7 @@
 # pragma once
 
 # if defined(OPENSSL_CPUID_OBJ)
-#  if defined(__aarch64__)
+#  if defined(__aarch64__) ||  defined (_M_ARM64)
 #   include "arm_arch.h"
 extern unsigned int OPENSSL_arm_midr;
 static inline int vpsm4_capable(void)


### PR DESCRIPTION
The first column indicates how many times Arm64 optimized version became faster on Windows
The rest of algorithms did not change much.

TimesFaster    Original / Arm64 optimized 

![image](https://github.com/Windows-on-ARM-Experiments/openssl/assets/1791423/1b9fc758-e3d2-40d8-b412-e1b4e0035d24)
